### PR TITLE
resolve conflicts with other Cordova plugins regarding to "allowbackup"

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -11,6 +11,13 @@
     <clobbers target="QueueIt" />
   </js-module>
 
+  <!--  resolve conflicts with other Cordova plugins by putting this part outside of <platform>-->
+  <edit-config file="app/src/main/AndroidManifest.xml"
+               target="/manifest/application"
+               mode="merge">
+    <application android:allowBackup="false"/>
+  </edit-config>
+
   <!-- android -->
   <platform name="android">
     <config-file target="res/xml/config.xml" parent="/*">
@@ -20,12 +27,6 @@
     </config-file>
     <framework src="com.queue_it.androidsdk:library:2.0.32"/>
     <source-file src="src/android/QueueIt.java" target-dir="src/com/queueit" />
-
-    <edit-config file="AndroidManifest.xml"
-                 target="/manifest/application"
-                 mode="merge">
-        <application android:allowBackup="false"/>
-    </edit-config>
   </platform>
 
   <!-- ios -->


### PR DESCRIPTION
adding the <edit-config> inside <platform> tag causes conflicts with other Cordova plugins when building the App.
By putting this part of the code outside and update the file path, the problem got perfectly resolved.
(tested and it works )

ref:
https://stackoverflow.com/questions/53279993/cordova-edit-config-not-updating-androidmanifest-xml/53282161#53282161